### PR TITLE
Adjusts tests to match previous updates

### DIFF
--- a/Example/Tests/SwiftPhotoGalleryTests.swift
+++ b/Example/Tests/SwiftPhotoGalleryTests.swift
@@ -74,7 +74,7 @@ class SwiftPhotoGalleryTests: XCTestCase {
 
         let timesAskedForNumberOfImagesInGallery = testHelper.timesAskedForNumberOfImagesInGallery
 
-        expect(self.testHelper.timesAskedForNumberOfImagesInGallery).to(equal(2))
+        expect(self.testHelper.timesAskedForNumberOfImagesInGallery).to(equal(4))
 
         testGallery.dataSource = testHelper
 


### PR DESCRIPTION
- Previous update added an additional call to numberOfImages in viewDidLoad, which caused tests to be expecting incorrect value